### PR TITLE
Create basic RPC implementations for extracting python information

### DIFF
--- a/ncclient/api/src/main/yang/ncclient.yang
+++ b/ncclient/api/src/main/yang/ncclient.yang
@@ -7,14 +7,27 @@ module ncclient {
         description "Initial revision.  Exposes some basic scaffolding to build the ncclient model.";
     }
 
-    rpc expose-python-info {
+    grouping unix-command-return {
+        leaf output {
+            type string;
+        }
+        leaf error {
+            type string;
+        }
+        leaf returnCode {
+            type int32;
+        }
+    }
+
+    rpc which-python {
         output {
-            leaf output {
-                type string;
-            }
-            leaf returnCode {
-                type string;
-            }
+            uses unix-command-return;
+        }
+    }
+
+    rpc python-version {
+        output {
+            uses unix-command-return;
         }
     }
 }

--- a/ncclient/impl/src/main/java/com/veloxsw/impl/NcclientProvider.java
+++ b/ncclient/impl/src/main/java/com/veloxsw/impl/NcclientProvider.java
@@ -8,6 +8,9 @@
 package com.veloxsw.impl;
 
 import org.opendaylight.controller.md.sal.binding.api.DataBroker;
+import org.opendaylight.controller.sal.binding.api.BindingAwareBroker;
+import org.opendaylight.controller.sal.binding.api.RpcProviderRegistry;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.ncclient.rev170225.NcclientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,15 +19,20 @@ public class NcclientProvider {
     private static final Logger LOG = LoggerFactory.getLogger(NcclientProvider.class);
 
     private final DataBroker dataBroker;
+    private final RpcProviderRegistry rpcProviderRegistry;
+    private BindingAwareBroker.RpcRegistration<NcclientService> rpcRegistration;
 
-    public NcclientProvider(final DataBroker dataBroker) {
+    public NcclientProvider(final DataBroker dataBroker, final RpcProviderRegistry rpcProviderRegistry) {
         this.dataBroker = dataBroker;
+        this.rpcProviderRegistry = rpcProviderRegistry;
     }
 
     /**
      * Method called when the blueprint container is created.
      */
     public void init() {
+        rpcRegistration = rpcProviderRegistry.addRpcImplementation(NcclientService.class,
+                new NcclientServiceImpl());
         LOG.info("NcclientProvider Session Initiated");
     }
 
@@ -32,6 +40,7 @@ public class NcclientProvider {
      * Method called when the blueprint container is destroyed.
      */
     public void close() {
+        rpcRegistration.close();
         LOG.info("NcclientProvider Closed");
     }
 }

--- a/ncclient/impl/src/main/java/com/veloxsw/impl/NcclientServiceImpl.java
+++ b/ncclient/impl/src/main/java/com/veloxsw/impl/NcclientServiceImpl.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2017 Velox Software and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package com.veloxsw.impl;
+
+import com.google.common.util.concurrent.Futures;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.ncclient.rev170225.*;
+import org.opendaylight.yangtools.yang.common.RpcResult;
+import org.opendaylight.yangtools.yang.common.RpcResultBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Scanner;
+import java.util.concurrent.Future;
+
+public class NcclientServiceImpl implements NcclientService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NcclientServiceImpl.class);
+
+    static final class UnixCommandReturnDTO {
+        private final String output;
+        private final String error;
+        private final int returnCode;
+
+        private UnixCommandReturnDTO(final String output, final String error, final int returnCode) {
+            this.output = output;
+            this.error = error;
+            this.returnCode = returnCode;
+        }
+
+        static UnixCommandReturnDTO create(final String output, final String error, final int returnCode) {
+            return new UnixCommandReturnDTO(output, error, returnCode);
+        }
+
+        public String getOutput() {
+            return output;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public int getReturnCode() {
+            return returnCode;
+        }
+    }
+
+    static final class StreamGobbler implements Runnable {
+        final InputStream inputStream;
+        String output;
+        private StreamGobbler(final InputStream inputStream) {
+           this.inputStream = inputStream;
+        }
+
+        static StreamGobbler create(final InputStream inputStream) {
+            return new StreamGobbler(inputStream);
+        }
+
+
+        @Override
+        public void run() {
+            final StringBuilder output = new StringBuilder();
+            final Scanner scanner = new Scanner(inputStream);
+            while (scanner.hasNext()) {
+                output.append(scanner.next());
+            }
+            this.output = output.toString();
+            LOG.error(this.output);
+            scanner.close();
+            try {
+                inputStream.close();
+            } catch (final IOException e) {
+                LOG.error("Fatal error reading stream", e);
+            }
+        }
+
+        String getOutput() {
+            return output;
+        }
+    }
+
+    private static UnixCommandReturnDTO execCommand(final String command) throws IOException, InterruptedException {
+        final Process process = Runtime.getRuntime().exec(command);
+
+        final StreamGobbler stdout = StreamGobbler.create(process.getInputStream());
+        final StreamGobbler stderr = StreamGobbler.create(process.getErrorStream());
+        final Thread outThread = new Thread(stdout);
+        final Thread errThread = new Thread(stderr);
+
+        outThread.start();
+        errThread.start();
+
+        process.waitFor();
+
+        outThread.join();
+        errThread.join();
+
+        return UnixCommandReturnDTO.create(stdout.getOutput(), stderr.getOutput(), process.exitValue());
+    }
+
+    @Override
+    public Future<RpcResult<PythonVersionOutput>> pythonVersion() {
+        try {
+            final UnixCommandReturnDTO ret = execCommand("python --version");
+            final PythonVersionOutputBuilder builder = new PythonVersionOutputBuilder();
+            builder.setOutput(ret.getOutput());
+            builder.setError(ret.getError());
+            builder.setReturnCode(ret.getReturnCode());
+            return RpcResultBuilder.success(builder).buildFuture();
+        } catch (final IOException | InterruptedException e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<RpcResult<WhichPythonOutput>> whichPython() {
+        try {
+            final UnixCommandReturnDTO ret = execCommand("which python");
+            final WhichPythonOutputBuilder builder = new WhichPythonOutputBuilder();
+            builder.setOutput(ret.getOutput());
+            builder.setError(ret.getError());
+            builder.setReturnCode(ret.getReturnCode());
+            return RpcResultBuilder.success(builder).buildFuture();
+        } catch (final IOException | InterruptedException e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+}

--- a/ncclient/impl/src/main/resources/org/opendaylight/blueprint/impl-blueprint.xml
+++ b/ncclient/impl/src/main/resources/org/opendaylight/blueprint/impl-blueprint.xml
@@ -15,10 +15,14 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
     interface="org.opendaylight.controller.md.sal.binding.api.DataBroker"
     odl:type="default" />
 
+  <reference id="rpcRegistry"
+             interface="org.opendaylight.controller.sal.binding.api.RpcProviderRegistry"/>
+
   <bean id="provider"
     class="com.veloxsw.impl.NcclientProvider"
     init-method="init" destroy-method="close">
     <argument ref="dataBroker" />
+    <argument ref="rpcRegistry" />
   </bean>
 
 </blueprint>


### PR DESCRIPTION
Add some RPCs to extract python information on the ODL server.  This
is useful since we will be integrating with ncclient, which runs on
python, which is not packaged with ODL by default.

Signed-off-by: Ryan Goulding <ryandgoulding@gmail.com>